### PR TITLE
Try to handle when a url is protocol-agnostic.

### DIFF
--- a/OpenGraphParser.js
+++ b/OpenGraphParser.js
@@ -36,7 +36,7 @@ function parseMeta(html, url, options) {
             }
 
             if (metaValue.length > 0) {
-                if (metaValue[0] === '/') {
+                if (metaValue[0] === '/' && (metaValue.length <= 1 || metaValue[1] !== '/')) {
                     if (url[url.length - 1] === '/') {
                         metaValue = url + metaValue.substring(1);
                     } else {

--- a/OpenGraphParser.js
+++ b/OpenGraphParser.js
@@ -36,11 +36,21 @@ function parseMeta(html, url, options) {
             }
 
             if (metaValue.length > 0) {
-                if (metaValue[0] === '/' && (metaValue.length <= 1 || metaValue[1] !== '/')) {
-                    if (url[url.length - 1] === '/') {
-                        metaValue = url + metaValue.substring(1);
+                if (metaValue[0] === '/') {
+                    if (metaValue.length <= 1 || metaValue[1] !== '/') {
+                        if (url[url.length - 1] === '/') {
+                            metaValue = url + metaValue.substring(1);
+                        } else {
+                            metaValue = url + metaValue;
+                        }
                     } else {
-                        metaValue = url + metaValue;
+                        // handle protocol agnostic meta URLs
+                        if (url.indexOf('https://') === 0) {
+                            metaValue = `https:${metaValue}`;
+                        }
+                        else if (url.indexOf('http://') === 0) {
+                            metaValue = `http:${metaValue}`;
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
i.e. the URL is formatted to work for whatever the current protocol is - i.e. http:// or https://

e.g. https://www.bbc.co.uk/news has a protocol agnostic meta tag:
`<meta property="og:image" content="//m.files.bbci.co.uk/modules/bbc-morph-news-waf-page-meta/1.2.0/bbc_news_logo.png?cb=1">`