### PR TITLE
Fix ViewPropTypes crash (release build only)

### DIFF
--- a/OpenGraphAwareInput.js
+++ b/OpenGraphAwareInput.js
@@ -3,6 +3,7 @@ import {
     StyleSheet,
     TextInput,
     View,
+    ViewPropTypes,
 } from 'react-native';
 import PropTypes from 'proptypes';
 import debounce from 'lodash.debounce';
@@ -21,7 +22,7 @@ const styles = StyleSheet.create({
 
 export default class OpenGraphAwareInput extends Component {
     static propTypes = {
-        containerStyle: View.propTypes.style,
+        containerStyle: ViewPropTypes.style,
         debounceDelay: PropTypes.number,
         iconSource: OpenGraphDisplay.propTypes.iconSource,
         iconStyle: OpenGraphDisplay.propTypes.iconStyle,

--- a/OpenGraphDisplay.js
+++ b/OpenGraphDisplay.js
@@ -20,6 +20,7 @@ import {
     StyleSheet,
     Text,
     TouchableWithoutFeedback,
+    ViewPropTypes,
 } from 'react-native';
 import PropTypes from 'proptypes';
 
@@ -80,7 +81,7 @@ const styles = StyleSheet.create({
 
 export default class OpenGraphDisplay extends Component {
     static propTypes = {
-        containerStyle: View.propTypes.style,
+        containerStyle: ViewPropTypes.style,
         descriptionStyle: Text.propTypes.style,
         data: PropTypes.shape({
             url: PropTypes.string,
@@ -92,12 +93,12 @@ export default class OpenGraphDisplay extends Component {
         iconStyle: Image.propTypes.style,
         imageStyle: Image.propTypes.style,
         onIconPress: PropTypes.func,
-        textContainerStyle: View.propTypes.style,
-        touchContainerStyle: View.propTypes.style,
+        textContainerStyle: ViewPropTypes.style,
+        touchContainerStyle: ViewPropTypes.style,
         titleStyle: Text.propTypes.style,
         urlStyle: Text.propTypes.style,
-        urlOnlyContainerStyle: View.propTypes.style,
-        urlOnlyTouchContainerStyle: View.propTypes.style,
+        urlOnlyContainerStyle: ViewPropTypes.style,
+        urlOnlyTouchContainerStyle: ViewPropTypes.style,
     };
 
     static defaultProps = {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A set of components and utils useful to extract opengraph data directly from your react-native app, with almost no dependency.
 
-For react-native v0.26+
+For react-native v0.44+
 
 # Prerequesites
 
@@ -38,7 +38,7 @@ import { OpenGraphAwareInput, OpenGraphDisplay, OpenGraphParser } from 'react-na
 
 Property Name | Type | Description
 --- | --- | ---
-containerStyle | View.propTypes.style | A style to pass to customize the style of the container
+containerStyle | ViewPropTypes.style | A style to pass to customize the style of the container
 onChange | React.PropTypes.func | The function to call on change in the TextInput
 textInputStyle | TextInput.propTypes.style | A style to pass to customize the style of the textInput
 onIconPress | React.PropTypes.func | A function to call when the Icon is pressed (see `OpenGraphDisplay`). By default, the function clear the `opengraphdata` field returned (and therefore the resulting `OpenGraphDisplay`).
@@ -59,14 +59,14 @@ Fully customizable widget for the extracted data
 Property Name | Type | Description
 --- | --- | ---
 data | React.PropTypes.shape({ <br>    url: React.PropTypes.string, <br>    image: React.PropTypes.string,<br>    title: React.PropTypes.string,<br>    description: React.PropTypes.string,<br>}).isRequired | The data gotten out of the `OpenGraphAwareInput` or the `OpenGraphParser`
-containerStyle | View.propTypes.style | A style to pass to customize the style of the container
+containerStyle | ViewPropTypes.style | A style to pass to customize the style of the container
 imageStyle | Image.propTypes.style | A style to pass to customize the style of the image
-textContainerStyle | View.propTypes.style | A style to pass to customize the style of the textContainer
-touchContainerStyle | View.propTypes.style | A style to pass to customize the style of the View that is touchable when the content is "rich" (as opposed to `urlOnlyTouchContainerStyle`)
+textContainerStyle | ViewPropTypes.style | A style to pass to customize the style of the textContainer
+touchContainerStyle | ViewPropTypes.style | A style to pass to customize the style of the View that is touchable when the content is "rich" (as opposed to `urlOnlyTouchContainerStyle`)
 titleStyle | Text.propTypes.style | A style to pass to customize the style of the title
 descriptionStyle | Text.propTypes.style | A style to pass to customize the style of the description
 urlStyle | Text.propTypes.style | A style to pass to customize the style of the url
-urlOnlyTouchContainerStyle | View.propTypes.style | A style to pass to customize the style of the View that is touchable when the content is "poor" (Just the url, no info has been successfully fetched)
+urlOnlyTouchContainerStyle | ViewPropTypes.style | A style to pass to customize the style of the View that is touchable when the content is "poor" (Just the url, no info has been successfully fetched)
 onIconPress | React.PropTypes.func | When this function is provided, puts an Icon on the right of the OpenGraphDisplay (by default an `x`)
 iconSource | Image.propTypes.source | The Image Source to use as Icon
 iconStyle | Image.propTypes.style | The style of the Icon


### PR DESCRIPTION
Getting a nasty crash only seen when you build the app for release.

```
2018-03-02 22:06:22.170776+0900 clintal[10036:152197] *** Terminating app due to uncaught exception 'RCTFatalException: Unhandled JS Exception: undefined is not an object (evaluating 'a.View.propTypes.style')', reason: 'Unhandled JS Exception: undefined is not an object (evaluating 'a.View.prop..., stack:
<unknown>@1627:3019
c@2:824
<unknown>@1624:241
c@2:824
<unknown>@1623:32
c@2:824
<unknown>@1597:422
c@2:824
<unknown>@1550:381
c@2:824
<unknown>@1548:301
c@2:824
<unknown>@1379:241
c@2:824
<unknown>@733:441
c@2:824
<unknown>@665:161
c@2:824
<unknown>@664:151
c@2:824
<unknown>@305:209
c@2:824
<unknown>@12:42
c@2:824
n@2:326
global code@2020:8
'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000011139012b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x000000010f80ff41 objc_exception_throw + 48
	2   clintal                             0x000000010dae6544 RCTFormatError + 0
	3   clintal                             0x000000010dae301a -[RCTExceptionsManager reportFatalException:stack:exceptionId:] + 507
	4   CoreFoundation                      0x000000011131436c __invoking___ + 140
	5   CoreFoundation                      0x0000000111314240 -[NSInvocation invoke] + 320
	6   CoreFoundation                      0x000000011132cc26 -[NSInvocation invokeWithTarget:] + 54
	7   clintal                             0x000000010daf9429 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 602
	8   clintal                             0x000000010db3f9ba _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 266
	9   clintal                             0x000000010db3f734 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 78
	10  libdispatch.dylib                   0x00000001155822f7 _dispatch_call_block_and_release + 12
	11  libdispatch.dylib                   0x000000011558333d _dispatch_client_callout + 8
	12  libdispatch.dylib                   0x000000011558b855 _dispatch_queue_serial_drain + 1162
	13  libdispatch.dylib                   0x000000011558c1ea _dispatch_queue_invoke + 336
	14  libdispatch.dylib                   0x0000000115587f7c _dispatch_queue_override_invoke + 733
	15  libdispatch.dylib                   0x000000011558f102 _dispatch_root_queue_drain + 772
	16  libdispatch.dylib                   0x000000011558eda0 _dispatch_worker_thread3 + 132
	17  libsystem_pthread.dylib             0x0000000115a4e1ca _pthread_wqthread + 1387
	18  libsystem_pthread.dylib             0x0000000115a4dc4d start_wqthread + 13
)
libc++abi.dylib: terminating with uncaught exception of type NSException
(lldb)
```

Happens because `View.propTypes.style` was deprecated back in react-native 0.44. Might be a breaking change for users on really old versions of React Native. I'm using 0.53 and 0.54 was released just today.